### PR TITLE
Fix bug in example in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@ procmaps = "0.4.1"
 use procmaps::Mappings;
 
 let mappings = Mappings::from_pid(pid).unwrap();
-for mapping in mappings {
+for mapping in mappings.iter() {
     if mapping.perms.executable {
         println!("Region: {:x} - {:x} Size: {}", mapping.base, mapping.ceiling, mapping.size_of_mapping());
     }


### PR DESCRIPTION
The example given in the README won't compile as the line `for mapping in mappings` won't actually produce an iterator. We need to use the `.iter()` method (or something else similar) of the internal vector to get something we can nicely iterate through.