### PR TITLE
Added support for Mappings::from_str(..)

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "procmaps"
-version = "0.4.1"
+version = "0.4.2"
 authors = ["Josh Abraham <sinisterpatrician@gmail.com>"]
 description = "Crate for gathering currently mapped memory regions for a given PID"
 keywords = ["unix", "memory", "process", "mappings", "proc"]

--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@ To use, add this line to your Cargo.toml:
 
 ```toml
 [dependencies]
-procmaps = "0.4.1"
+procmaps = "0.4.2"
 ```
 ## Example
 ```rust

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -215,16 +215,7 @@ impl Mappings {
         let mut file = File::open(path)?;
         let mut input = String::new();
         file.read_to_string(&mut input)?;
-
-        let mut res: Vec<Map> = Vec::new();
-        let mut iter: Vec<&str> = input.split("\n").collect();
-        iter.pop();
-        for s in iter {
-            let map = Map::from_str(&format!("{}\n", &s))?;
-            res.push(map);
-        }
-
-        Ok(Mappings(res))
+        Mappings::from_str(&input)
     }
 
     pub fn from_path(path: &mut PathBuf) -> Result<Mappings> {
@@ -232,7 +223,10 @@ impl Mappings {
         let mut file = File::open(path)?;
         let mut input = String::new();
         file.read_to_string(&mut input)?;
-
+        Mappings::from_str(&input)
+    }
+    pub fn from_str(raw : &str) -> Result<Mappings> {
+        let input = String::from(raw);
         let mut res: Vec<Map> = Vec::new();
         let mut iter: Vec<&str> = input.split("\n").collect();
         iter.pop();


### PR DESCRIPTION
I have recently come across a use case where it would be great to be able to read the proc maps of a process that is not currently executing. Specifically, https://github.com/rr-debugger/rr is able to provide the proc map of a previously executed process, but only in the form of a string. It would be really cool to be able to use your small tool to read those files.

As such, I have added support for reading proc maps as str instead of just pid_t and PathBufs. 

I have also refactored the other two from_.. methods to use from_str(..)

Please let me know if you have any thoughts! I am very grateful for your project!
